### PR TITLE
Fix ddr4 putscom

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -60,9 +60,9 @@ trees is also simple enough to embed in other projects.
 
 ## Node representation
 
-The [libpdbg API](@ref libpdbg.h) provides functions for building up a complete device-tree
-representation of a POWER system based on the current system state along with functions
-for traversing the tree.
+The [libpdbg API](@ref libpdbg.h) provides functions for building up a complete
+device-tree representation of a POWER system based on the current system state
+along with functions for traversing the tree.
 
 Each node is represented in a program by a @ref pdbg_target. This is used with
 most API functions to specify the target of a particular command. At a minimum
@@ -168,9 +168,10 @@ allow application specific types to be specified.
 
 # Frontends
 
-For programmatic access it is preferable to use the [libpdbg API](@ref libpdbg.h)
-directly. For command line usage there are two primary frontends available. Both
-frontends will work on the platforms specified in @ref hardware-access.
+For programmatic access it is preferable to use the [libpdbg API](@ref
+libpdbg.h) directly. For command line usage there are two primary frontends
+available. Both frontends will work on the platforms specified in @ref
+hardware-access.
 
 ### pdbg
 

--- a/libpdbg/ocmb.c
+++ b/libpdbg/ocmb.c
@@ -71,7 +71,9 @@ static int sbefifo_ocmb_putscom(struct ocmb *ocmb, uint64_t addr, uint64_t value
 		struct sbefifo_context *sctx = sbefifo->get_sbefifo_context(sbefifo);
 		uint8_t instance_id;
 
-		instance_id = pdbg_target_index(&ocmb->target) & 0x0f;
+		uint32_t fapi_pos = 0;
+		pdbg_target_get_attribute(&ocmb->target, "ATTR_FAPI_POS", 4, 1, &fapi_pos);
+		instance_id = fapi_pos & 0x0f;
 
 		return sbefifo_hw_register_put(sctx,
 						SBEFIFO_TARGET_TYPE_OCMB,


### PR DESCRIPTION
On DDR4, some error injections reached the wrong target because the instance_id calculation used in chipop was incorrect. This fix corrects the calculation to ensure proper targeting.