### PR TITLE
Add hwaccess library framework

### DIFF
--- a/target/hwaccess/hw_access_intf.C
+++ b/target/hwaccess/hw_access_intf.C
@@ -1,0 +1,103 @@
+#include <hw_access_intf.H>
+#include "hw_base_access.H"
+#include "hw_direct_access.H"
+#include "hw_sbe_access.H"
+
+namespace hwaccess
+{
+using HwAccessPtr = TARGETING::AttributeTraits<TARGETING::ATTR_HW_ACCESS_PTR>::Type;
+
+int HwAccessIntf::getCfamRegister(ConstTargetPtr_t target, uint32_t addr, uint32_t& val)
+{
+    if(target == nullptr)
+    {
+        std::cerr << "getCfamRegister: target is nullptr" << std::endl;
+        return -1;
+    }
+
+    auto accessPtr = target->getAttr<TARGETING::ATTR_HW_ACCESS_PTR>();
+    HwBaseAccess* hwAccessPtr = reinterpret_cast<HwBaseAccess*>(static_cast<HwAccessPtr>(accessPtr));
+
+    if (hwAccessPtr == nullptr)
+    {
+        std::cerr << "getCfamRegister: hwAccessPtr is nullptr" << std::endl;
+        return -1;
+    }
+
+    return hwAccessPtr->getCfam(target, addr, val);
+}
+
+int HwAccessIntf::putCfamRegister(ConstTargetPtr_t target, uint32_t addr, uint32_t val)
+{
+    if(target == nullptr)
+    {
+        std::cerr << "putCfamRegister: target is nullptr" << std::endl;
+        return -1;
+    }
+
+    auto accessPtr = target->getAttr<TARGETING::ATTR_HW_ACCESS_PTR>();
+    HwBaseAccess* hwAccessPtr = reinterpret_cast<HwBaseAccess*>(static_cast<HwAccessPtr>(accessPtr));
+
+    if (hwAccessPtr == nullptr)
+    {
+        std::cerr << "putCfamRegister: hwAccessPtr is nullptr" << std::endl;
+        return -1;
+    }
+
+    return hwAccessPtr->putCfam(target, addr, val);
+}
+
+int HwAccessIntf::getScomRegister(ConstTargetPtr_t target, uint64_t addr, uint64_t& val)
+{
+    if(target == nullptr)
+    {
+        std::cerr << "getScomRegister: target is nullptr" << std::endl;
+        return -1;
+    }
+
+    auto accessPtr = target->getAttr<TARGETING::ATTR_HW_ACCESS_PTR>();
+    HwBaseAccess* hwAccessPtr = reinterpret_cast<HwBaseAccess*>(static_cast<HwAccessPtr>(accessPtr));
+
+    if (hwAccessPtr == nullptr)
+    {
+        std::cerr << "getScomRegister: hwAccessPtr is nullptr" << std::endl;
+        return -1;
+    }
+
+    return hwAccessPtr->getScom(target, addr, val);
+}
+
+int HwAccessIntf::putScomRegister(ConstTargetPtr_t target, uint64_t addr, uint64_t val)
+{
+    if(target == nullptr)
+    {
+        std::cerr << "putScomRegister: target is nullptr" << std::endl;
+        return -1;
+    }
+
+    auto accessPtr = target->getAttr<TARGETING::ATTR_HW_ACCESS_PTR>();
+    HwBaseAccess* hwAccessPtr = reinterpret_cast<HwBaseAccess*>(static_cast<HwAccessPtr>(accessPtr));
+
+    if (hwAccessPtr == nullptr)
+    {
+        std::cerr << "putScomRegister: hwAccessPtr is nullptr" << std::endl;
+        return -1;
+    }
+
+    return hwAccessPtr->putScom(target, addr, val);
+}
+
+void* HwAccessIntf::getHwAccessPtr(HwAccessMethod& accessMethod)
+{
+    if(accessMethod == TARGETING::HW_ACCESS_METHOD_DIRECT_ACCESS)
+    {
+        return static_cast<void*>(&HwDirectAccess::getInstance());
+    }
+    else if(accessMethod == TARGETING::HW_ACCESS_METHOD_SBEFIFO)
+    {
+        return static_cast<void*>(&HwSbeAccess::getInstance());
+    }
+    std::cerr << "getHwAccessPtr: HwAccessMethod is invalid" << std::endl;
+    return nullptr;
+}
+} //namespace hwaccess

--- a/target/hwaccess/hw_access_intf.C
+++ b/target/hwaccess/hw_access_intf.C
@@ -1,4 +1,4 @@
-#include <hw_access_intf.H>
+#include "hw_access_intf.H"
 #include "hw_base_access.H"
 #include "hw_direct_access.H"
 #include "hw_sbe_access.H"

--- a/target/hwaccess/hw_access_intf.H
+++ b/target/hwaccess/hw_access_intf.H
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <target.H>
-#include <attributeenums.H>
-#include <attributetraits.H>
+#include <targeting/target.H>
+#include <targeting/xmltohb/attributeenums.H>
+#include <targeting/xmltohb/attributetraits.H>
 
 namespace hwaccess
 {

--- a/target/hwaccess/hw_access_intf.H
+++ b/target/hwaccess/hw_access_intf.H
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <target.H>
+#include <attributeenums.H>
+#include <attributetraits.H>
+
+namespace hwaccess
+{
+
+using HwAccessMethod   = TARGETING::AttributeTraits<TARGETING::ATTR_HW_ACCESS_METHOD>::Type;
+using ConstTargetPtr_t = TARGETING::ConstTargetPtr;
+
+/**
+ * @class HwAccessIntf
+ * @brief Provides static interface methods to perform register operations via hwaccess.
+ *
+ * Exceptions will be thrown when register operations are attempted without
+ * setting HwAccessMethod. The setHwAccessMethod is provided by the target service.
+ * User is expected to catch and handle the exceptions.
+ */
+class HwAccessIntf
+{
+public:
+    /**
+     * @brief Fetch a CFAM register.
+     *
+     * @param[in]  target   Target on which the operation needs to be done.
+     * @param[in]  addr     Address of the CFAM register to fetch.
+     * @param[out] val      Retrieved data will be stored here.
+     *
+     * @return Return code of the operation from the transport layer.
+     */
+    static int getCfamRegister(ConstTargetPtr_t target, uint32_t addr, uint32_t& val);
+
+    /**
+     * @brief Write to a CFAM register.
+     *
+     * @param[in] target   Target on which the operation needs to be done.
+     * @param[in] addr     Address of the CFAM register to write.
+     * @param[in] val      Data to be written into the register.
+     *
+     * @return Return code of the operation from the transport layer.
+     */
+    static int putCfamRegister(ConstTargetPtr_t target, uint32_t addr, uint32_t val);
+
+    /**
+     * @brief Fetch a SCOM register.
+     *
+     * @param[in]  target   Target on which the operation needs to be done.
+     * @param[in]  addr     Address of the SCOM register to fetch.
+     * @param[out] val      Retrieved data will be stored here.
+     *
+     * @return Return code of the operation from the transport layer.
+     */
+    static int getScomRegister(ConstTargetPtr_t target, uint64_t addr, uint64_t& val);
+
+    /**
+     * @brief Write to a SCOM register.
+     *
+     * @param[in] target   Target on which the operation needs to be done.
+     * @param[in] addr     Address of the SCOM register to write.
+     * @param[in] val      Data to be written into the register.
+     *
+     * @return Return code of the operation from the transport layer.
+     */
+    static int putScomRegister(ConstTargetPtr_t target, uint64_t addr, uint64_t val);
+
+    /**
+     * @brief Fetch the HwAccessPtr relevant to the use case.
+     *
+     * @param[in] accessMethod   Access method (e.g., direct or sbefifo).
+     *
+     * @return Pointer to the requested hardware access object.
+     */
+    static void* getHwAccessPtr(HwAccessMethod& accessMethod);
+};
+
+} // namespace hwaccess

--- a/target/hwaccess/hw_base_access.C
+++ b/target/hwaccess/hw_base_access.C
@@ -1,6 +1,6 @@
 #include "hw_base_access.H"
 
-#include <transport.H>
+#include <transport/transport.H>
 
 namespace hwaccess
 {

--- a/target/hwaccess/hw_base_access.C
+++ b/target/hwaccess/hw_base_access.C
@@ -1,0 +1,30 @@
+#include "hw_base_access.H"
+
+#include <transport.H>
+
+namespace hwaccess
+{
+int HwBaseAccess::getCfam(ConstTargetPtr_t target, uint32_t addr, uint32_t& val)
+{
+    if(target == nullptr)
+    {
+        std::cerr << "HwBaseAccess::getCfam target is nullptr" << std::endl;
+        return -1;
+    }
+
+    std::cout << "HwBaseAccess::getCfam executed" << std::endl;
+    return transport::getCfam(target, addr, val);
+}
+
+int HwBaseAccess::putCfam(ConstTargetPtr_t target, uint32_t addr, uint32_t val)
+{
+    if(target == nullptr)
+    {
+        std::cerr << "HwBaseAccess::putCfam target is nullptr" << std::endl;
+        return -1;
+    }
+    
+    std::cout << "HwBaseAccess::putCfam executed" << std::endl;
+    return transport::putCfam(target, addr, val);
+}
+} //namespace hwaccess

--- a/target/hwaccess/hw_base_access.H
+++ b/target/hwaccess/hw_base_access.H
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <target.H>
-#include <attributeenums.H>
-#include <attributetraits.H>
-#include <hw_access_intf.H>
+#include <targeting/target.H>
+#include <targeting/xmltohb/attributeenums.H>
+#include <targeting/xmltohb/attributetraits.H>
+#include <hwaccess/hw_access_intf.H>
 
 namespace hwaccess
 {

--- a/target/hwaccess/hw_base_access.H
+++ b/target/hwaccess/hw_base_access.H
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <target.H>
+#include <attributeenums.H>
+#include <attributetraits.H>
+#include <hw_access_intf.H>
+
+namespace hwaccess
+{
+/**
+ * @class HwBaseAccess
+ * @brief Base class providing hardware access interface for CFAM and SCOM operations.
+ *
+ * This class defines the common interface for hardware access implementations.
+ * Derived classes are expected to override SCOM operations.
+ */
+class HwBaseAccess 
+{
+protected:
+    /**
+     * @brief Protected default constructor to prevent direct instantiation.
+     */
+    HwBaseAccess() = default;
+
+    /**
+     * @brief Deleted copy constructor.
+     */
+    HwBaseAccess(const HwBaseAccess&) = delete;
+
+    /**
+     * @brief Deleted copy assignment operator.
+     */
+    HwBaseAccess& operator=(const HwBaseAccess&) = delete;
+
+    /**
+     * @brief Virtual destructor for safe polymorphic deletion.
+     */
+    virtual ~HwBaseAccess() = default;
+
+public:
+    /**
+     * @brief Perform a CFAM read operation.
+     *
+     * @param[in]  target Target on which the operation needs to be done.
+     * @param[in]  addr   Address to read from.
+     * @param[out] val    Reference to store the read value.
+     *
+     * @return Status code (0 on success, non-zero on error).
+     */
+    int getCfam(ConstTargetPtr_t target, uint32_t addr, uint32_t& val);
+
+    /**
+     * @brief Perform a CFAM write operation.
+     *
+     * @param[in] target Target on which the operation needs to be done.
+     * @param[in] addr   Address to write to.
+     * @param[in] val    Value to write.
+     *
+     * @return Status code (0 on success, non-zero on error).
+     */
+    int putCfam(ConstTargetPtr_t target, uint32_t addr, uint32_t val);
+
+    /**
+     * @brief Perform a SCOM read operation (default implementation).
+     *
+     * @param[in]  target Target on which the operation needs to be done.
+     * @param[in]  addr   SCOM address.
+     * @param[out] val    Reference to store the read value.
+     *
+     * @return Status code (-1 by default).
+     */
+    virtual int getScom(ConstTargetPtr_t target, uint64_t addr, uint64_t& val) { return -1; }
+
+    /**
+     * @brief Perform a SCOM write operation (default implementation).
+     *
+     * @param[in] target Target on which the operation needs to be done.
+     * @param[in] addr   SCOM address.
+     * @param[in] val    Value to write.
+     *
+     * @return Status code (-1 by default).
+     */
+    virtual int putScom(ConstTargetPtr_t target, uint64_t addr, uint64_t val) { return -1; }
+};
+}  // namespace hwaccess

--- a/target/hwaccess/hw_direct_access.C
+++ b/target/hwaccess/hw_direct_access.C
@@ -1,0 +1,36 @@
+#include "hw_direct_access.H"
+
+#include <transport.H>
+
+namespace hwaccess
+{
+HwDirectAccess& HwDirectAccess::getInstance()
+{
+    static HwDirectAccess directAccessInstance;
+    return directAccessInstance;
+}
+
+int HwDirectAccess::getScom(ConstTargetPtr_t target, uint64_t addr, uint64_t& val)
+{
+    if(target == nullptr)
+    {
+        std::cerr << "HwDirectAccess::getScom target is nullptr" << std::endl;
+        return -1;
+    }
+
+    std::cout << "HwDirectAccess::getScom executed" << std::endl;
+    return transport::getScom(target, addr, val);
+}
+
+int HwDirectAccess::putScom(ConstTargetPtr_t target, uint64_t addr, uint64_t val)
+{
+    if(target == nullptr)
+    {
+        std::cerr << "HwDirectAccess::putScom target is nullptr" << std::endl;
+        return -1;
+    }
+
+    std::cout << "HwDirectAccess::putScom executed" << std::endl;
+    return transport::putScom(target, addr, val);
+}
+} // namespace hwaccess

--- a/target/hwaccess/hw_direct_access.C
+++ b/target/hwaccess/hw_direct_access.C
@@ -1,6 +1,6 @@
 #include "hw_direct_access.H"
 
-#include <transport.H>
+#include <transport/transport.H>
 
 namespace hwaccess
 {

--- a/target/hwaccess/hw_direct_access.H
+++ b/target/hwaccess/hw_direct_access.H
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "hw_base_access.H"
+
+namespace hwaccess
+{
+/**
+ * @class HwDirectAccess
+ * @brief Provides direct hardware access implementation for SCOM operations.
+ *
+ * This class is a concrete implementation of HwBaseAccess that allows
+ * performing direct SCOM reads and writes on a target.
+ */
+class HwDirectAccess : public HwBaseAccess
+{
+protected:
+    /**
+     * @brief Protected default constructor to enforce singleton usage.
+     */
+    HwDirectAccess() = default;
+
+    /**
+     * @brief Deleted copy constructor.
+     */
+    HwDirectAccess(const HwDirectAccess&) = delete;
+
+    /**
+     * @brief Deleted copy assignment operator.
+     */
+    HwDirectAccess& operator=(const HwDirectAccess&) = delete;
+
+public:
+    /**
+     * @brief Retrieve the singleton instance of HwDirectAccess.
+     *
+     * @return Reference to the singleton instance.
+     */
+    static HwDirectAccess& getInstance();
+
+    /**
+     * @brief Perform a SCOM read operation.
+     *
+     * @param[in] target Target on which the operation needs to be done.
+     * @param[in] addr   SCOM address.
+     * @param[out] val    Reference to store the read value.
+     *
+     * @return Status code (0 on success, non-zero on error).
+     */
+    virtual int getScom(ConstTargetPtr_t target, uint64_t addr, uint64_t& val) override final;
+
+    /**
+     * @brief Perform a SCOM write operation.
+     *
+     * @param[in] target Target on which the operation needs to be done.
+     * @param[in] addr   SCOM address.
+     * @param[in] val    Value to write.
+     *
+     * @return Status code (0 on success, non-zero on error).
+     */
+    virtual int putScom(ConstTargetPtr_t target, uint64_t addr, uint64_t val) override final;
+};
+} // namespace hwaccess

--- a/target/hwaccess/hw_sbe_access.C
+++ b/target/hwaccess/hw_sbe_access.C
@@ -1,0 +1,36 @@
+#include "hw_sbe_access.H"
+
+namespace hwaccess
+{
+HwSbeAccess& HwSbeAccess::getInstance()
+{
+    static HwSbeAccess sbeAccessInstance;
+    return sbeAccessInstance;
+}
+
+int HwSbeAccess::getScom(ConstTargetPtr_t target, uint64_t addr, uint64_t& val)
+{
+    if(target == nullptr)
+    {
+        std::cerr << "HwSbeAccess::getScom target is nullptr" << std::endl;
+        return -1;
+    }
+
+    std::cout << "HwSbeAccess::getScom executed" << std::endl;
+    
+    return 0; // TBD: Call to SBEI::getScom
+}
+
+int HwSbeAccess::putScom(ConstTargetPtr_t target, uint64_t addr, uint64_t val)
+{
+    if(target == nullptr)
+    {
+        std::cerr << "HwSbeAccess::putScom target is nullptr" << std::endl;
+        return -1;
+    }
+
+    std::cout << "HwSbeAccess::putScom executed" << std::endl;
+
+    return 0; // TBD: Call to SBEI::putScom
+}
+} //namespace hwaccess

--- a/target/hwaccess/hw_sbe_access.H
+++ b/target/hwaccess/hw_sbe_access.H
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "hw_base_access.H"
+
+namespace hwaccess
+{
+/**
+ * @class HwSbeAccess
+ * @brief Provides hardware access via the Self-Boot Engine (SBE).
+ *
+ * This class is a concrete implementation of HwBaseAccess that
+ * performs SCOM read and write operations through the SBE interface.
+ */
+class HwSbeAccess : public HwBaseAccess
+{
+protected:
+    /**
+     * @brief Protected default constructor to enforce singleton usage.
+     */
+    HwSbeAccess() = default;
+
+    /**
+     * @brief Deleted copy constructor.
+     */
+    HwSbeAccess(const HwSbeAccess&) = delete;
+
+    /**
+     * @brief Deleted copy assignment operator.
+     */
+    HwSbeAccess& operator=(const HwSbeAccess&) = delete;
+
+public:
+    /**
+     * @brief Retrieve the singleton instance of HwSbeAccess.
+     *
+     * @return Reference to the singleton instance.
+     */
+    static HwSbeAccess& getInstance();
+
+    /**
+     * @brief Perform a SCOM read operation via SBE.
+     *
+     * @param[in]  target Target on which the operation needs to be done.
+     * @param[in]  addr   SCOM address.
+     * @param[out] val    Reference to store the read value.
+     *
+     * @return Status code (0 on success, non-zero on error).
+     */
+    virtual int getScom(ConstTargetPtr_t target, uint64_t addr, uint64_t& val) override final;
+
+    /**
+     * @brief Perform a SCOM write operation via SBE.
+     *
+     * @param[in] target Target on which the operation needs to be done.
+     * @param[in] addr   SCOM address.
+     * @param[in] val    Value to write.
+     *
+     * @return Status code (0 on success, non-zero on error).
+     */
+    virtual int putScom(ConstTargetPtr_t target, uint64_t addr, uint64_t val) override final;
+};
+} // namespace hwaccess

--- a/target/hwaccess/meson.build
+++ b/target/hwaccess/meson.build
@@ -5,9 +5,7 @@ hwaccess_sources = files(
   'hw_sbe_access.C',
 )
 
-hwaccess_inc = include_directories(
-  '.',
-)
+hwaccess_inc = include_directories('..')
 
 hwaccess_lib = shared_library(
   'hwaccess',
@@ -20,10 +18,25 @@ hwaccess_lib = shared_library(
 )
 
 # Export public headers into /usr/include/hwaccess
-install_headers('hw_access_intf.H', subdir: 'hwaccess')
+install_headers(
+  'hw_access_intf.H',
+  subdir: 'hwaccess',
+  preserve_path: true,
+)
 
 hwaccess_dep = declare_dependency(
     link_with: hwaccess_lib,
     include_directories: hwaccess_inc
 )
 
+pkgconfig = import('pkgconfig')
+
+pkgconfig.generate(
+  libraries: hwaccess_lib,
+  version: meson.project_version(),
+  filebase: 'libhwaccess',
+  name: 'libhwaccess',
+  description: 'Hardware access library',
+  subdirs: 'hwaccess',
+  requires: ['libfdt', 'libtargeting', 'libtransport']
+)

--- a/target/hwaccess/meson.build
+++ b/target/hwaccess/meson.build
@@ -1,0 +1,29 @@
+hwaccess_sources = files(
+  'hw_access_intf.C',
+  'hw_base_access.C',
+  'hw_direct_access.C',
+  'hw_sbe_access.C',
+)
+
+hwaccess_inc = include_directories(
+  '.',
+)
+
+hwaccess_lib = shared_library(
+  'hwaccess',
+  hwaccess_sources,
+  include_directories: [hwaccess_inc],
+  dependencies: [libfdt_dep, targeting_dep, transport_dep],
+  version: '1.0.0',
+  soversion: '1',
+  install: true
+)
+
+# Export public headers into /usr/include/hwaccess
+install_headers('hw_access_intf.H', subdir: 'hwaccess')
+
+hwaccess_dep = declare_dependency(
+    link_with: hwaccess_lib,
+    include_directories: hwaccess_inc
+)
+

--- a/target/libfdt/meson.build
+++ b/target/libfdt/meson.build
@@ -28,10 +28,12 @@ endif
 
 link_args += version_script
 libfdt = library(
-  'fdt', sources,
+  'fdt-custom', sources,
   version: meson.project_version(),
   link_args: link_args,
   link_depends: 'version.lds',
+  version: '1.0.0',
+  soversion: '1',
   install: get_option('default_library') != 'static' or not wheel_only,
 )
 
@@ -47,7 +49,8 @@ install_headers(
     'fdt.h',
     'libfdt.h',
     'libfdt_env.h',
-  )
+  ),
+  subdir: 'fdt-custom'
 )
 
 pkgconfig = import('pkgconfig')
@@ -55,7 +58,7 @@ pkgconfig = import('pkgconfig')
 pkgconfig.generate(
   libraries: libfdt,
   version: meson.project_version(),
-  filebase: 'libfdt',
-  name: 'libfdt',
+  filebase: 'libfdt-custom',
+  name: 'libfdt-custom',
   description: 'Flat Device Tree manipulation',
 )

--- a/target/meson.build
+++ b/target/meson.build
@@ -1,8 +1,9 @@
 # Include libfdt
 subdir('libfdt')
 subdir('targeting')
-subdir('targetsvc')
 subdir('transport')
+subdir('hwaccess')
+subdir('targetsvc')
 subdir('test')
 
 # Build main executable linking with both libraries

--- a/target/targeting/common/attributes.H
+++ b/target/targeting/common/attributes.H
@@ -15,5 +15,5 @@
 #include <stdlib.h>
 
 // This component
-#include <attributeenums.H>
-#include <entitypath.H>
+#include <targeting/xmltohb/attributeenums.H>
+#include "entitypath.H"

--- a/target/targeting/common/entitypath.C
+++ b/target/targeting/common/entitypath.C
@@ -1,4 +1,4 @@
-#include <entitypath.H>
+#include "entitypath.H"
 
 #include <algorithm>
 #include <cassert>

--- a/target/targeting/common/entitypath.H
+++ b/target/targeting/common/entitypath.H
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <attributeenums.H>
+#include <targeting/xmltohb/attributeenums.H>
 
 #include <array>
 #include <cassert>

--- a/target/targeting/meson.build
+++ b/target/targeting/meson.build
@@ -5,7 +5,7 @@ targeting_lib_sources = files(
     'xmltohb/targAttrIdToName.C',
 )
 
-targeting_inc = include_directories('..', '.', 'xmltohb', 'common', 'predicates')
+targeting_inc = include_directories('..', 'xmltohb')
 
 targeting_lib = shared_library(
     'targeting',
@@ -21,9 +21,12 @@ targeting_lib = shared_library(
 install_headers(
     'target.H',
     'association.H',
+    'target_tmpl.H',
     'xmltohb/attributeenums.H',
     'xmltohb/attributetraits.H',
     'xmltohb/attributestructs.H',
+    'xmltohb/builtins.h',
+    'xmltohb/targAttrIdToName.H',
     'common/entitypath.H',
     'predicates/predicateattr.H',
     'predicates/predicateattrval.H',
@@ -31,10 +34,23 @@ install_headers(
     'predicates/predicateisfunctional.H',
     'predicates/predicatepostfixexpr.H',
     subdir: 'targeting',
+    preserve_path: true,
 )
 
 # Declare dependency for consumers
 targeting_dep = declare_dependency(
     link_with: targeting_lib,
     include_directories: targeting_inc
+)
+
+pkgconfig = import('pkgconfig')
+
+pkgconfig.generate(
+  libraries: targeting_lib,
+  version: meson.project_version(),
+  filebase: 'libtargeting',
+  name: 'libtargeting',
+  description: 'Targeting library',
+  subdirs: 'targeting',
+  requires: ['libfdt']
 )

--- a/target/targeting/predicates/predicatebase.H
+++ b/target/targeting/predicates/predicatebase.H
@@ -1,5 +1,5 @@
 #pragma once
-#include <target.H>
+#include <targeting/target.H>
 
 namespace TARGETING
 {

--- a/target/targeting/target.H
+++ b/target/targeting/target.H
@@ -232,4 +232,4 @@ class Target
 
 } // namespace TARGETING
 
-#include "target_tmpl.H" // Template implementations
+#include "targeting/target_tmpl.H" // Template implementations

--- a/target/targeting/target_tmpl.H
+++ b/target/targeting/target_tmpl.H
@@ -112,7 +112,7 @@ void Target::setAttr(const typename AttributeTraits<A>::Type& attrValue)
     (void)AttributeTraits<A>::writeable;
     if constexpr (requires { AttributeTraits<A>::isvolatile; })
     {
-        setVolatileAttr(A, attrValue);
+        setVolatileAttr<A>(attrValue);
         return;
     }
     setAttrImpl<A>(attrValue);
@@ -124,7 +124,7 @@ void Target::setAttr(const typename AttributeTraits<A>::TypeStdArr& attrValue)
     (void)AttributeTraits<A>::writeable;
     if constexpr (requires { AttributeTraits<A>::isvolatile; })
     {
-        setVolatileAttr(A, attrValue);
+        setVolatileAttr<A>(attrValue);
         return;
     }
     setAttrImpl<A>(attrValue);
@@ -149,7 +149,7 @@ bool Target::trySetAttr(
     (void)AttributeTraits<A>::writeable;
     if constexpr (requires { AttributeTraits<A>::isvolatile; })
     {
-        setVolatileAttr(A, attrValue);
+        setVolatileAttr<A>(attrValue);
         return true;
     }
     return trySetAttrImpl<A>(attrValue);

--- a/target/targeting/xmltohb/attributestructs.H
+++ b/target/targeting/xmltohb/attributestructs.H
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 
 // Targeting component
-#include <builtins.h>
+#include <targeting/xmltohb/builtins.h>
 
 #include <targeting/common/entitypath.H>
 

--- a/target/targetsvc/meson.build
+++ b/target/targetsvc/meson.build
@@ -10,7 +10,7 @@ targetsvc_lib = shared_library(
   'targetsvc',
   service_lib_sources,
   include_directories: targetsvc_inc,
-  dependencies: [libfdt_dep, targeting_dep],
+  dependencies: [libfdt_dep, targeting_dep, hwaccess_dep],
   version: '1.0.0',
   soversion: '1',
   install: true,
@@ -22,5 +22,5 @@ install_headers('target_service.H', subdir: 'targeting')
 targetsvc_dep = declare_dependency(
   link_with: targetsvc_lib,
   include_directories: targetsvc_inc,
-  dependencies: [targeting_dep, libfdt_dep],
+  dependencies: [targeting_dep, libfdt_dep, hwaccess_dep],
 )

--- a/target/targetsvc/meson.build
+++ b/target/targetsvc/meson.build
@@ -4,7 +4,7 @@ service_lib_sources = files(
     'target_service.C',
 )
 
-targetsvc_inc = include_directories('.')
+targetsvc_inc = include_directories('..')
 
 targetsvc_lib = shared_library(
   'targetsvc',
@@ -17,10 +17,28 @@ targetsvc_lib = shared_library(
 )
 
 # Export public headers into /usr/include/target
-install_headers('target_service.H', subdir: 'targeting')
+install_headers(
+  'target_service.H',
+  'target_devtree_map.H',
+  'dtree_loader.H',
+  subdir: 'targeting',
+  preserve_path: true,
+)
 
 targetsvc_dep = declare_dependency(
   link_with: targetsvc_lib,
   include_directories: targetsvc_inc,
   dependencies: [targeting_dep, libfdt_dep, hwaccess_dep],
+)
+
+pkgconfig = import('pkgconfig')
+
+pkgconfig.generate(
+  libraries: targetsvc_lib,
+  version: meson.project_version(),
+  filebase: 'libtargetsvc',
+  name: 'libtargetsvc',
+  description: 'Targeting service library',
+  subdirs: 'targeting',
+  requires: ['libtargeting', 'libfdt', 'libhwaccess']
 )

--- a/target/targetsvc/target_devtree_map.C
+++ b/target/targetsvc/target_devtree_map.C
@@ -1,4 +1,4 @@
-#include <target_devtree_map.H>
+#include "target_devtree_map.H"
 
 namespace TARGETING
 {

--- a/target/targetsvc/target_service.C
+++ b/target/targetsvc/target_service.C
@@ -3,7 +3,7 @@ extern "C"
 {
 #include <libfdt.h>
 }
-#include <hw_access_intf.H>
+#include <hwaccess/hw_access_intf.H>
 
 #include <fstream>
 #include <vector>

--- a/target/targetsvc/target_service.C
+++ b/target/targetsvc/target_service.C
@@ -3,6 +3,7 @@ extern "C"
 {
 #include <libfdt.h>
 }
+#include <hw_access_intf.H>
 
 #include <fstream>
 #include <vector>
@@ -66,5 +67,15 @@ TargetPtr TargetService::getTopLevelTarget() const
         return nullptr;
     }
     return _targetMap->getTopLevelTarget();
+}
+
+void TargetService::setHwAccessMethod(TargetPtr target, HwAccessMethod accessMethod)
+{
+    target->setAttr<ATTR_HW_ACCESS_METHOD>(accessMethod);
+
+    uintptr_t accessPtr =
+            reinterpret_cast<uintptr_t>(hwaccess::HwAccessIntf::getHwAccessPtr(accessMethod));
+
+    target->setAttr<ATTR_HW_ACCESS_PTR>(static_cast<HwAccessPtrType>(accessPtr));
 }
 } // namespace TARGETING

--- a/target/targetsvc/target_service.H
+++ b/target/targetsvc/target_service.H
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "target_devtree_map.H"
+#include "dtree_loader.H"
 #include <targeting/association.H>
-#include <dtree_loader.H>
 #include <targeting/predicates/predicatebase.H>
 #include <targeting/target.H>
-#include <target_devtree_map.H>
 
 #include <cstdint>
 

--- a/target/targetsvc/target_service.H
+++ b/target/targetsvc/target_service.H
@@ -10,6 +10,9 @@
 
 namespace TARGETING
 {
+using HwAccessMethod = AttributeTraits<ATTR_HW_ACCESS_METHOD>::Type;
+using HwAccessPtrType = AttributeTraits<ATTR_HW_ACCESS_PTR>::Type;
+
 /**
  * @class TargetService
  * @brief Provides a singleton interface to access and query target objects from a device tree.
@@ -92,6 +95,15 @@ class TargetService
      * @return Pointer to the top-level target, or nullptr if not found.
      */
     TargetPtr getTopLevelTarget() const;
+
+    /**
+     * @brief Set the hardware access method for a specified target
+     *
+     * @param[in] target HwTarget to set the access method
+     * @param[in] accessMethod HwAccessMethod to use
+     *
+     */
+    void setHwAccessMethod(TargetPtr target, HwAccessMethod accessMethod);
 
   private:
     /**

--- a/target/transport/meson.build
+++ b/target/transport/meson.build
@@ -3,7 +3,7 @@ transport_sources = files(
   'transport.C',
 )
 
-transport_inc = include_directories('.')
+transport_inc = include_directories('..')
 
 libtransport = shared_library(
   'transport',
@@ -24,6 +24,18 @@ transport_dep = declare_dependency(
 # Install headers under transport
 install_headers(
   'transport.H',
-  subdir: 'transport'
+  subdir: 'transport',
+  preserve_path: true,
 )
 
+pkgconfig = import('pkgconfig')
+
+pkgconfig.generate(
+  libraries: libtransport,
+  version: meson.project_version(),
+  filebase: 'libtransport',
+  name: 'libtransport',
+  description: 'transport library',
+  subdirs: 'transport',
+  requires: ['libtargeting', 'libfdt']
+)


### PR DESCRIPTION
Verified:
Verified that upon setting certain access method, respective methods are getting called.
Installed the targeting-app & targeting libs on bmc image using recipe, and getCfam operation was successful.
This demonstrates the .so libraries (targeting, hwaccess and transport) are correctly installed and working as expected.

root@p11bmc:/tmp/targeting# ./targeting-app
PROC: Physical:/Sys0/Node0/MI0

//Set HwAccessMethod to Direct Access
HwBaseAccess::getCfam executed
HwBaseAccess::putCfam executed

//Set HwAccessMethod to SBEFIFO
HwBaseAccess::getCfam executed
HwBaseAccess::putCfam executed

HwSbeAccess::getScom executed
HwSbeAccess::putScom executed

//Set HwAccessMethod to Direct Access
HwDirectAccess::getScom executed
HwDirectAccess::putScom executed

targeting-app: getCfamRegister
HwBaseAccess::getCfam executed
getFSIBasePath Found FSI base path: /sys/class/fsi-master/
getcfam for addr=0x2810 value=0x80ff6007