### PR TITLE
Fix device paths

### DIFF
--- a/bmc-sbefifo-rbmc.dts.m4
+++ b/bmc-sbefifo-rbmc.dts.m4
@@ -7,7 +7,7 @@ define(`SBEFIFO',
 		reg = <0x0 0x2400 0x7>;
 		compatible = "ibm,kernel-sbefifo";
 		index = <0x$1>;
-		device-path = "/dev/fsi/sbefifo$2";
+		device-path = "/dev/fsi/sbefifo$1";
 
 		sbefifo-pib {
 			#address-cells = <0x2>;
@@ -71,7 +71,7 @@ define(`HMFSI',
 		#address-cells = <0x2>;
 		#size-cells = <0x1>;
 		compatible = "ibm,kernel-fsi";
-		device-path = "/fsi1/slave@0$2:00/raw";
+		device-path = "/fsi0/slave@$2:00/raw";
 		reg = <0x0 0x$1 0x8000>;
 		port = <0x$2>;
 		index = <0x$3>;


### PR DESCRIPTION
Test Results:

Before:
```
[root@rbmc-prototype (0:active)] ~ # getcfam pu 1007 -all
pu	k0:n0:s0:p00       0xB0200844
/usr/bin/edbg getcfam pu 1007 -all 
```

After:
```
[root@rbmc-prototype (0:active)] /tmp # getcfam pu 1007 -all
pu	k0:n0:s0:p00       0xB0200844
pu	k0:n0:s0:p01       0x02200004
pu	k0:n0:s0:p02       0x08200A44
pu	k0:n0:s0:p03       0xA0200004
/usr/bin/edbg getcfam pu 1007 -all 
```


Scom results:
```
[root@rbmc-prototype (0:active)] /tmp # getscom pu 50008
pu	k0:n0:s0:p00       0x0000000000000000
/usr/bin/edbg getscom pu 50008 
```